### PR TITLE
Add Open Collective to the list of supporting organizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Below is a list of companies and teams that have committed line items on their b
 | Company / Team | Description                 | Engineers | GitHub org                                 | OpenCollective                       |
 |----------------|-----------------------------|-----------|--------------------------------------------|--------------------------------------|
 | Thinkmill       | $100 per engineer, per year | 1-50      | [@Thinkmill](https://github.com/Thinkmill) | https://opencollective.com/thinkmill |
+| Open Collective | Up to $100 per engineer, per month | 1-50      | [@OpenCollective](https://github.com/opencollective) | https://opencollective.com/opencollectiveinc |
 
 There are many ways that companies support open source. And there's no one or right way to do it, but having it committed on the budget, makes all the difference. If your company or team has a committed budget for open source, [please submit a PR to be added](https://github.com/BudgetForOpenSource/website/edit/master/README.md).
 


### PR DESCRIPTION
Hi there!

Thank you for this great initiative, there are a bunch of companies out there that are already commited to support open source. I won't speak in their names, but I know that Airbnb, Triplebyte or Salesforce among others are increasingly participating both on Open Collective and via other means.

In the case of Open Collective Inc (the company behind the project) every engineer is granted a monthly $100 gift card that they can use to contribute to the projects of their choice. Though most of us use it to contribute to open-source, we can also contribute to other kinds of initiatives with this amount (like climate initiatives, civic tech...etc) which is why I put ***Up** to $100 per engineer, per month* in the description.

The reference for info about compensation & employees gift cards at Open Collective lays on https://docs.opencollective.com/help/about/the-open-collective-way/core-contributors-compensation